### PR TITLE
Migrate flutter_inset_box_shadow to flutter_inset_shadow and wide gamut color spaces

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,8 +59,8 @@ class _MyAppState extends State<MyApp> {
                   shape: BoxShape.circle,
                   gradient: LinearGradient(
                     colors: [
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.05),
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.1)
+                      Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.05),
+                      Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.1),
                     ],
                   ),
                 ),
@@ -97,14 +97,8 @@ class _MyAppState extends State<MyApp> {
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [
-                            Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withOpacity(0.05),
-                            Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withOpacity(0.1)
+                            Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.05),
+                            Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.1),
                           ],
                         ),
                       ),
@@ -114,9 +108,11 @@ class _MyAppState extends State<MyApp> {
                           tab = i;
                           _tabDataSet(i == 0);
                           controller
-                              .animateToPage(tab,
-                                  duration: const Duration(milliseconds: 100),
-                                  curve: Curves.linear)
+                              .animateToPage(
+                                tab,
+                                duration: const Duration(milliseconds: 100),
+                                curve: Curves.linear,
+                              )
                               .whenComplete(() => setState(() {}));
                         },
                         children: [
@@ -127,25 +123,15 @@ class _MyAppState extends State<MyApp> {
                               shape: BoxShape.circle,
                               gradient: LinearGradient(
                                 colors: [
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withOpacity(0.05),
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withOpacity(0.1)
+                                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.05),
+                                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.1),
                                 ],
                               ),
                             ),
-                            child: Text(i.toString(),
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .labelLarge
-                                    ?.copyWith(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary)),
+                            child: Text(
+                              i.toString(),
+                              style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Theme.of(context).colorScheme.primary),
+                            ),
                           ),
                           Container(
                             alignment: Alignment.center,
@@ -156,25 +142,15 @@ class _MyAppState extends State<MyApp> {
                                 begin: Alignment.centerRight,
                                 end: Alignment.centerLeft,
                                 colors: [
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withOpacity(0.05),
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withOpacity(0.1)
+                                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.05),
+                                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.1),
                                 ],
                               ),
                             ),
-                            child: Text(i.toString(),
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .labelLarge
-                                    ?.copyWith(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary)),
+                            child: Text(
+                              i.toString(),
+                              style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Theme.of(context).colorScheme.primary),
+                            ),
                           ),
                         ],
                       ),
@@ -185,17 +161,17 @@ class _MyAppState extends State<MyApp> {
                   // minTime: minTime,
                   // maxTime: maxTime,
                   // depth: 5,
-                  // shadowColorDark: Theme.of(context).shadowColor.withOpacity(0.5),
+                  // shadowColorDark: Theme.of(context).shadowColor.withValues(alpha: 0.5),
                   // shadowColorLight: Theme.of(context).canvasColor,
-                  // shadowColorDark: Theme.of(context).primaryColor.withOpacity(0.5),
+                  // shadowColorDark: Theme.of(context).primaryColor.withValues(alpha: 0.5),
                   // shadowColorLight: Theme.of(context).canvasColor,
                   // childBuilder: (currentTime) {
                   //   return Container(
                   //     decoration: BoxDecoration(
                   //       gradient: LinearGradient(
                   //         colors: [
-                  //           Colors.black.withOpacity(0.05),
-                  //           Colors.black.withOpacity(0.1)
+                  //           Colors.black.withValues(alpha: 0.05),
+                  //           Colors.black.withValues(alpha: 0.1)
                   //           // Colors.amber,
                   //           // Colors.amberAccent,
                   //         ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,18 +37,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -62,14 +62,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_inset_box_shadow:
+  flutter_inset_shadow:
     dependency: transitive
     description:
-      name: flutter_inset_box_shadow
-      sha256: "0b1930ed5f4ad84b11b41dda907fbc5d4c12929a4c51455c626e5937b47ffb93"
+      name: flutter_inset_shadow
+      sha256: "5978b67f028c7ca3566516eda14f0a25a5ce13c0fa21a86a48a0b00faa7db9d7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "2.0.3"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -87,18 +87,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -151,7 +151,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -164,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -196,17 +196,17 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.3"
   time_range_selector_widget:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "2.0.2"
+    version: "2.0.3"
   vector_math:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.3.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/time_range_selector_widget.dart
+++ b/lib/src/time_range_selector_widget.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart' hide BoxDecoration, BoxShadow;
-import 'package:flutter_inset_box_shadow/flutter_inset_box_shadow.dart';
+import 'package:flutter_inset_shadow/flutter_inset_shadow.dart';
 
 class TimeRangeSelectorWidget extends StatefulWidget {
   const TimeRangeSelectorWidget({
@@ -85,8 +85,7 @@ class TimeRangeSelectorWidget extends StatefulWidget {
   final double? stockWidth;
 
   @override
-  State<TimeRangeSelectorWidget> createState() =>
-      _TimeRangeSelectorWidgetState();
+  State<TimeRangeSelectorWidget> createState() => _TimeRangeSelectorWidgetState();
 }
 
 class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
@@ -100,8 +99,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
   void initState() {
     super.initState();
 
-    if (widget.initialTime < widget.minTime ||
-        widget.initialTime > widget.maxTime) {
+    if (widget.initialTime < widget.minTime || widget.initialTime > widget.maxTime) {
       throw Exception("Current time must be in time range (Max and min time)");
     }
 
@@ -115,10 +113,8 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
 
   setValue() {
     stockWidth = widget.stockWidth ?? Theme.of(context).buttonTheme.height;
-    handlePadding =
-        widget.handlePadding ?? Theme.of(context).buttonTheme.height / 3;
-    positionalDotSize =
-        widget.positionalDotSize ?? Theme.of(context).buttonTheme.height / 8;
+    handlePadding = widget.handlePadding ?? Theme.of(context).buttonTheme.height / 3;
+    positionalDotSize = widget.positionalDotSize ?? Theme.of(context).buttonTheme.height / 8;
   }
 
   Widget drawBox({Widget? child, bool? isHandle, int? index}) {
@@ -129,9 +125,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
     if (widget.positionalDotColor != null) {
       dotColor = widget.positionalDotColor!;
     } else if (index != null) {
-      dotColor = currentPosition < index
-          ? Theme.of(context).colorScheme.onSurface
-          : Theme.of(context).colorScheme.onPrimary;
+      dotColor = currentPosition < index ? Theme.of(context).colorScheme.onSurface : Theme.of(context).colorScheme.onPrimary;
     }
 
     return Container(
@@ -149,32 +143,16 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: widget.shadowColorLight ??
-                blendColors(
-                        baseColor: Colors.transparent,
-                        blendColor: Colors.white,
-                        blendMode: BlendModeType.screen)
-                    .withOpacity(0.5),
+            color: widget.shadowColorLight ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.white, blendMode: BlendModeType.screen).withOpacity(0.5),
             blurRadius: s,
             offset: Offset(-s, -s),
-            inset: isHandle != null
-                ? !isHandle
-                : child ==
-                    null, // This line should be comment if you don't want to use "flutter_inset_box_shadow" package
+            inset: isHandle != null ? !isHandle : child == null, // This line should be comment if you don't want to use "flutter_inset_shadow" package
           ),
           BoxShadow(
-            color: widget.shadowColorDark ??
-                blendColors(
-                        baseColor: Colors.transparent,
-                        blendColor: Colors.black,
-                        blendMode: BlendModeType.multiply)
-                    .withOpacity(0.5),
+            color: widget.shadowColorDark ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.black, blendMode: BlendModeType.multiply).withOpacity(0.5),
             blurRadius: s,
             offset: Offset(s, s),
-            inset: isHandle != null
-                ? !isHandle
-                : child ==
-                    null, // This line should be comment if you don't want to use "flutter_inset_box_shadow" package
+            inset: isHandle != null ? !isHandle : child == null, // This line should be comment if you don't want to use "flutter_inset_shadow" package
           ),
         ],
       ),
@@ -182,14 +160,8 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
     );
   }
 
-  Widget dot(
-      double centerX, double centerY, double radius, int index, bool isHandle) {
-    Offset offset = _countOffset(
-        centerX: centerX,
-        centerY: centerY,
-        radius: radius,
-        currentPosition: index,
-        totalPosition: totalPosition);
+  Widget dot(double centerX, double centerY, double radius, int index, bool isHandle) {
+    Offset offset = _countOffset(centerX: centerX, centerY: centerY, radius: radius, currentPosition: index, totalPosition: totalPosition);
 
     Widget w;
 
@@ -213,8 +185,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
       //   w = (widget.positionalDotBuilder!(index, offset)) ?? const SizedBox();
       // }
 
-      if (widget.positionalDotBuilder != null &&
-          widget.positionalDotBuilder!(index, offset) != null) {
+      if (widget.positionalDotBuilder != null && widget.positionalDotBuilder!(index, offset) != null) {
         w = widget.positionalDotBuilder!(index, offset)!;
       }
     }
@@ -265,13 +236,11 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
         builder: (context, box) {
           double centerX = box.maxWidth / 2;
           double centerY = box.maxHeight / 2;
-          final radius = min((box.maxHeight / 2) - (stockWidth / 2),
-              (box.maxWidth / 2) - (stockWidth / 2));
+          final radius = min((box.maxHeight / 2) - (stockWidth / 2), (box.maxWidth / 2) - (stockWidth / 2));
 
           return Container(
             clipBehavior: Clip.antiAlias,
-            decoration: BoxDecoration(
-                shape: BoxShape.circle, color: widget.backgroundColor),
+            decoration: BoxDecoration(shape: BoxShape.circle, color: widget.backgroundColor),
             child: Stack(
               alignment: Alignment.center,
               children: [
@@ -279,8 +248,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
                 Positioned.fill(
                   child: CustomPaint(
                     painter: _CustomClockPickerPaint(
-                      stockColor: widget.stockColor ??
-                          Theme.of(context).colorScheme.primary,
+                      stockColor: widget.stockColor ?? Theme.of(context).colorScheme.primary,
                       stokeWidth: stockWidth,
                       time: currentPosition,
                       totalTime: totalPosition,
@@ -292,8 +260,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
                 Positioned.fill(child: drawBox()),
 
                 /// --------------------------------------------------------------------------------------- Small Dots
-                for (int i = 0; i < totalPosition; i++)
-                  dot(centerX, centerY, radius, i, false),
+                for (int i = 0; i < totalPosition; i++) dot(centerX, centerY, radius, i, false),
 
                 /// --------------------------------------------------------------------------------------- Big Dot
                 dot(centerX, centerY, radius, currentPosition, true),
@@ -302,15 +269,11 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
                 Positioned.fill(
                   child: GestureDetector(
                     onPanDown: (details) {
-                      double angle = angleCounter(
-                          Size(box.maxWidth, box.maxHeight),
-                          details.localPosition);
+                      double angle = angleCounter(Size(box.maxWidth, box.maxHeight), details.localPosition);
                       changeTime(angle);
                     },
                     onPanUpdate: (details) {
-                      double angle = angleCounter(
-                          Size(box.maxWidth, box.maxHeight),
-                          details.localPosition);
+                      double angle = angleCounter(Size(box.maxWidth, box.maxHeight), details.localPosition);
                       changeTime(angle);
                     },
                     child: Container(
@@ -337,10 +300,7 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
                 drawBox(
                   child: AspectRatio(
                     aspectRatio: 1,
-                    child: widget.childBuilder == null
-                        ? const SizedBox()
-                        : widget
-                            .childBuilder!(currentPosition + widget.minTime),
+                    child: widget.childBuilder == null ? const SizedBox() : widget.childBuilder!(currentPosition + widget.minTime),
                   ),
                 ),
               ],
@@ -370,8 +330,7 @@ class _CustomClockPickerPaint extends CustomPainter {
     final centerX = size.width / 2;
     final centerY = size.height / 2;
     final center = Offset(centerX, centerY);
-    final radius = min((size.height / 2) - (stokeWidth / 2),
-        (size.width / 2) - (stokeWidth / 2));
+    final radius = min((size.height / 2) - (stokeWidth / 2), (size.width / 2) - (stokeWidth / 2));
 
     //! -------------------------------------------------------------------------------------------- Line
     var arcPaint = Paint()
@@ -390,24 +349,14 @@ class _CustomClockPickerPaint extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
 }
 
-Offset _countOffset(
-    {required double centerX,
-    required double centerY,
-    required double radius,
-    required int currentPosition,
-    required int totalPosition}) {
-  double x = centerX +
-      radius * cos((270 + (360 * currentPosition / totalPosition)) * pi / 180);
-  double y = centerY +
-      radius * sin((270 + (360 * currentPosition / totalPosition)) * pi / 180);
+Offset _countOffset({required double centerX, required double centerY, required double radius, required int currentPosition, required int totalPosition}) {
+  double x = centerX + radius * cos((270 + (360 * currentPosition / totalPosition)) * pi / 180);
+  double y = centerY + radius * sin((270 + (360 * currentPosition / totalPosition)) * pi / 180);
   return Offset(x, y);
 }
 
 //! ------------------------------------------------------------------------------------------------ Colors
-Color blendColors(
-    {required Color baseColor,
-    required Color blendColor,
-    required BlendModeType blendMode}) {
+Color blendColors({required Color baseColor, required Color blendColor, required BlendModeType blendMode}) {
   double normalize(int value) => value / 255.0;
 
   int clamp(double value) => value.clamp(0, 255).toInt();
@@ -427,18 +376,9 @@ Color blendColors(
     case BlendModeType.screen:
       return Color.fromARGB(
         baseColor.alpha,
-        clamp((1 -
-                (1 - normalize(baseColor.red)) *
-                    (1 - normalize(blendColor.red))) *
-            255),
-        clamp((1 -
-                (1 - normalize(baseColor.green)) *
-                    (1 - normalize(blendColor.green))) *
-            255),
-        clamp((1 -
-                (1 - normalize(baseColor.blue)) *
-                    (1 - normalize(blendColor.blue))) *
-            255),
+        clamp((1 - (1 - normalize(baseColor.red)) * (1 - normalize(blendColor.red))) * 255),
+        clamp((1 - (1 - normalize(baseColor.green)) * (1 - normalize(blendColor.green))) * 255),
+        clamp((1 - (1 - normalize(baseColor.blue)) * (1 - normalize(blendColor.blue))) * 255),
       );
 
     default:

--- a/lib/src/time_range_selector_widget.dart
+++ b/lib/src/time_range_selector_widget.dart
@@ -73,7 +73,7 @@ class TimeRangeSelectorWidget extends StatefulWidget {
   final Color? shadowColorDark;
 
   /// Depth shadow Color
-  /// Default: blendColors(baseColor: Colors.transparent, blendColor: Colors.white, blendMode: BlendModeType.screen).withOpacity(0.7)
+  /// Default: blendColors(baseColor: Colors.transparent, blendColor: Colors.white, blendMode: BlendModeType.screen).withValues(alpha: 0.7)
   final Color? shadowColorLight;
 
   /// Stock / Progress bar color
@@ -143,13 +143,13 @@ class _TimeRangeSelectorWidgetState extends State<TimeRangeSelectorWidget> {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: widget.shadowColorLight ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.white, blendMode: BlendModeType.screen).withOpacity(0.5),
+            color: widget.shadowColorLight ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.white, blendMode: BlendModeType.screen).withValues(alpha: 0.5),
             blurRadius: s,
             offset: Offset(-s, -s),
             inset: isHandle != null ? !isHandle : child == null, // This line should be comment if you don't want to use "flutter_inset_shadow" package
           ),
           BoxShadow(
-            color: widget.shadowColorDark ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.black, blendMode: BlendModeType.multiply).withOpacity(0.5),
+            color: widget.shadowColorDark ?? blendColors(baseColor: Colors.transparent, blendColor: Colors.black, blendMode: BlendModeType.multiply).withValues(alpha: 0.5),
             blurRadius: s,
             offset: Offset(s, s),
             inset: isHandle != null ? !isHandle : child == null, // This line should be comment if you don't want to use "flutter_inset_shadow" package
@@ -357,28 +357,27 @@ Offset _countOffset({required double centerX, required double centerY, required 
 
 //! ------------------------------------------------------------------------------------------------ Colors
 Color blendColors({required Color baseColor, required Color blendColor, required BlendModeType blendMode}) {
-  double normalize(int value) => value / 255.0;
-
-  int clamp(double value) => value.clamp(0, 255).toInt();
+  double normalize(double value) => value / 255.0;
+  double clamp(double value) => value.clamp(0, 255);
 
   switch (blendMode) {
     case BlendModeType.normal:
       return baseColor;
 
     case BlendModeType.multiply:
-      return Color.fromARGB(
-        baseColor.alpha,
-        clamp(normalize(baseColor.red) * normalize(blendColor.red) * 255),
-        clamp(normalize(baseColor.green) * normalize(blendColor.green) * 255),
-        clamp(normalize(baseColor.blue) * normalize(blendColor.blue) * 255),
+      return Color.from(
+        alpha: baseColor.a,
+        red: clamp(normalize(baseColor.r) * normalize(blendColor.r) * 255),
+        green: clamp(normalize(baseColor.g) * normalize(blendColor.g) * 255),
+        blue: clamp(normalize(baseColor.b) * normalize(blendColor.b) * 255),
       );
 
     case BlendModeType.screen:
-      return Color.fromARGB(
-        baseColor.alpha,
-        clamp((1 - (1 - normalize(baseColor.red)) * (1 - normalize(blendColor.red))) * 255),
-        clamp((1 - (1 - normalize(baseColor.green)) * (1 - normalize(blendColor.green))) * 255),
-        clamp((1 - (1 - normalize(baseColor.blue)) * (1 - normalize(blendColor.blue))) * 255),
+      return Color.from(
+        alpha: baseColor.a,
+        red: clamp((1 - (1 - normalize(baseColor.r)) * (1 - normalize(blendColor.r))) * 255),
+        green: clamp((1 - (1 - normalize(baseColor.g)) * (1 - normalize(blendColor.g))) * 255),
+        blue: clamp((1 - (1 - normalize(baseColor.b)) * (1 - normalize(blendColor.b))) * 255),
       );
 
     default:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,29 +4,27 @@ name: time_range_selector_widget
 description: |
   Quickly select the hourly time range by dragging the circular bar.
 
-version: 2.0.2
+version: 2.0.3
 repository: https://github.com/SHAJED99/time_range_selector_widget
 license: BSD 3-Clause
 
 screenshots:
-  - description: 'Example of time_range_selector_widget'
+  - description: "Example of time_range_selector_widget"
     path: screenshots/1.gif
-
 
 topics:
   - time-range
   - time
   - time-selector
 
-
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: ">=2.12.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inset_box_shadow: ^1.0.8
+  flutter_inset_shadow: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Migration from flutter_inset_box_shadow to [flutter_inset_shadow](https://github.com/chitochi/flutter_inset_shadow)
> What happened to flutter_inset_box_shadow?
> 
> Previously, this package was called flutter_inset_box_shadow.
> 
> Unfortunately, I've lost access to the verified publisher, allowing me to publish updates to the package.
> 
> So I decided to publish the package under a new name.
> 
> For more information, you can read https://github.com/chitochi/flutter_inset_shadow/issues/7. 😄

### Migration for wide gamut color spaces
The API for the [Color](https://api.flutter.dev/flutter/dart-ui/Color-class.html) class in dart:ui is changing to support [wide gamut color spaces](https://en.wikipedia.org/wiki/RGB_color_spaces).
More information can be found in the [migration guide](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework).